### PR TITLE
feat: 번역 진행률 표시 기능 추가

### DIFF
--- a/src/main/java/com/project/Transflow/document/dto/LockStatusResponse.java
+++ b/src/main/java/com/project/Transflow/document/dto/LockStatusResponse.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
@@ -28,6 +29,9 @@ public class LockStatusResponse {
 
     @Schema(description = "편집 가능 여부", example = "true")
     private Boolean canEdit;
+
+    @Schema(description = "완료된 문단 인덱스 목록", example = "[0, 1, 2]")
+    private List<Integer> completedParagraphs;
 
     @Getter
     @Setter


### PR DESCRIPTION
- LockStatusResponse에 completedParagraphs 필드 추가
- DocumentLockController에서 completedParagraphs 저장 로직 구현
  - saveTranslation: 임시 저장 시 completedParagraphs 저장
  - completeTranslation: 번역 완료 시 completedParagraphs 저장
  - getLockStatus: completedParagraphs를 JSON에서 파싱하여 응답에 포함