### PR TITLE
feat: 용어집 페이지 통합 및 기능 확장

### DIFF
--- a/src/main/java/com/project/Transflow/term/controller/TermDictionaryController.java
+++ b/src/main/java/com/project/Transflow/term/controller/TermDictionaryController.java
@@ -17,11 +17,15 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -233,6 +237,88 @@ public class TermDictionaryController {
         } catch (IllegalArgumentException e) {
             return ResponseEntity.notFound().build();
         }
+    }
+
+    @Operation(
+            summary = "용어집 전체 내보내기",
+            description = "전체 용어를 TSV 형식으로 내보냅니다. 형식: 구분(탭)영어(탭)한국어(탭)기사제목(탭)출처(탭)기사링크(탭)메모. 권한: 관리자 이상 (roleLevel 1, 2)"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "내보내기 성공 (TSV 파일)"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (관리자 권한 필요)")
+    })
+    @GetMapping("/export")
+    public ResponseEntity<String> exportTerms(
+            @Parameter(hidden = true) @RequestHeader("Authorization") String authHeader,
+            @Parameter(description = "원문 언어 필터", example = "EN")
+            @RequestParam(required = false) String sourceLang,
+            @Parameter(description = "번역 언어 필터", example = "KO")
+            @RequestParam(required = false) String targetLang) {
+
+        // 권한 체크 (관리자 이상)
+        if (!adminAuthUtil.isAdminOrAbove(authHeader)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        try {
+            // 필터링된 용어 목록 조회
+            List<TermDictionaryResponse> terms;
+            if (sourceLang != null && targetLang != null) {
+                terms = termDictionaryService.findByLanguages(sourceLang, targetLang);
+            } else if (sourceLang != null) {
+                terms = termDictionaryService.findBySourceLang(sourceLang);
+            } else if (targetLang != null) {
+                terms = termDictionaryService.findByTargetLang(targetLang);
+            } else {
+                terms = termDictionaryService.findAll();
+            }
+
+            // TSV 형식으로 변환 (헤더 포함)
+            StringBuilder tsv = new StringBuilder();
+            tsv.append("구분(분야)\t영어\t한국어\t기사제목\t출처(날짜)\t기사링크\t메모\n");
+
+            for (TermDictionaryResponse term : terms) {
+                tsv.append(escapeTsv(term.getCategory() != null ? term.getCategory() : ""))
+                   .append("\t")
+                   .append(escapeTsv(term.getSourceTerm()))
+                   .append("\t")
+                   .append(escapeTsv(term.getTargetTerm()))
+                   .append("\t")
+                   .append(escapeTsv(term.getArticleTitle() != null ? term.getArticleTitle() : ""))
+                   .append("\t")
+                   .append(escapeTsv(term.getArticleSource() != null ? term.getArticleSource() : ""))
+                   .append("\t")
+                   .append(escapeTsv(term.getArticleLink() != null ? term.getArticleLink() : ""))
+                   .append("\t")
+                   .append(escapeTsv(term.getMemo() != null ? term.getMemo() : ""))
+                   .append("\n");
+            }
+
+            // 파일 다운로드를 위한 헤더 설정
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.TEXT_PLAIN);
+            headers.setContentDispositionFormData("attachment", "glossary_export.tsv");
+            headers.setContentLength(tsv.toString().getBytes(StandardCharsets.UTF_8).length);
+
+            return ResponseEntity.ok()
+                    .headers(headers)
+                    .body(tsv.toString());
+
+        } catch (Exception e) {
+            log.error("용어집 내보내기 실패", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * TSV 형식에서 특수문자 이스케이프 (탭과 개행문자 제거)
+     */
+    private String escapeTsv(String text) {
+        if (text == null) {
+            return "";
+        }
+        // TSV에서 탭과 개행문자는 공백으로 변환
+        return text.replace("\t", " ").replace("\n", " ").replace("\r", " ");
     }
 }
 

--- a/src/main/java/com/project/Transflow/translate/service/TranslationService.java
+++ b/src/main/java/com/project/Transflow/translate/service/TranslationService.java
@@ -20,13 +20,10 @@ public class TranslationService {
 
     private final WebClient webClient;
     private final ApiKeyService apiKeyService;
-    private final String fallbackApiKey; // .env 파일의 백업 키 (DB에 없을 때 사용)
 
     public TranslationService(
             @Value("${deepl.api.url}") String apiUrl,
-            @Value("${deepl.api.key:}") String fallbackApiKey,
             ApiKeyService apiKeyService) {
-        this.fallbackApiKey = fallbackApiKey;
         this.apiKeyService = apiKeyService;
         this.webClient = WebClient.builder()
                 .baseUrl(apiUrl)
@@ -35,7 +32,7 @@ public class TranslationService {
     }
 
     /**
-     * DeepL API 키 조회 (DB 우선, 없으면 .env 백업 키 사용)
+     * DeepL API 키 조회 (DB에서 복호화)
      */
     private String getApiKey() {
         try {
@@ -44,13 +41,7 @@ public class TranslationService {
                 return dbApiKey;
             }
         } catch (Exception e) {
-            log.warn("DB에서 API 키 조회 실패, 백업 키 사용: {}", e.getMessage());
-        }
-
-        // DB에 키가 없으면 .env 파일의 백업 키 사용
-        if (fallbackApiKey != null && !fallbackApiKey.isEmpty()) {
-            log.info(".env 백업 API 키 사용");
-            return fallbackApiKey;
+            log.error("DB에서 API 키 조회 실패: {}", e.getMessage());
         }
 
         throw new RuntimeException("DeepL API 키가 설정되지 않았습니다. 시스템 설정에서 API 키를 등록해주세요.");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,4 +80,4 @@ encryption:
 deepl:
   api:
     url: ${DEEPL_API_URL:https://api-free.deepl.com/v2/translate}
-    key: ${DEEPL_API_KEY:}
+    # key: ${DEEPL_API_KEY:}  # 더 이상 사용하지 않음 (DB에서 관리)


### PR DESCRIPTION
- 용어 추가/수정 모달에 모든 필드 추가 (구분, 기사제목, 출처, 기사링크, 메모)
- 용어집 보기/관리 페이지 통합 (권한 기반 조건부 렌더링)
- 테이블에 카테고리 컬럼 추가
- 검색 기능에 카테고리, 기사제목 필드 포함
- 라우팅 및 사이드바 메뉴 정리 (/glossary/manage 제거)
- GlossaryManage.tsx 파일 삭제