### PR TITLE
feat/issue-62/이메일로 번역 완료 공지 및 평어 번역 및 UI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     // Spring Security & OAuth2
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     // OAuth2 Authorization Server for Spring Boot 2.7.x
     implementation 'org.springframework.security:spring-security-oauth2-authorization-server:0.4.1'

--- a/src/main/java/com/project/Transflow/document/controller/DocumentController.java
+++ b/src/main/java/com/project/Transflow/document/controller/DocumentController.java
@@ -10,6 +10,7 @@ import com.project.Transflow.document.dto.UpdateDocumentRequest;
 import com.project.Transflow.document.service.DocumentService;
 import com.project.Transflow.document.service.HandoverHistoryService;
 import com.project.Transflow.document.service.DocumentVersionService;
+import com.project.Transflow.notification.service.TranslationNotificationMailService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -45,6 +46,7 @@ public class DocumentController {
     private final HandoverHistoryService handoverHistoryService;
     private final AdminAuthUtil adminAuthUtil;
     private final UserRepository userRepository;
+    private final TranslationNotificationMailService translationNotificationMailService;
 
     @Operation(
             summary = "문서 생성",
@@ -391,6 +393,15 @@ public class DocumentController {
         documentService.updateDocument(documentId, updateRequest, userId);
 
         documentService.clearAdminTranslationSessionIfEditingCopy(documentId);
+
+        String documentTitle = documentService.findById(documentId)
+                .map(DocumentResponse::getTitle)
+                .orElse("(제목 없음)");
+        try {
+            translationNotificationMailService.sendTranslationCompletedToAdmins(documentId, documentTitle);
+        } catch (Exception e) {
+            log.error("번역 완료 알림 메일 발송 실패: documentId={}", documentId, e);
+        }
 
         return ResponseEntity.ok(Map.of("success", true, "message", "번역이 완료되었습니다.", "status", "PENDING_REVIEW"));
     }

--- a/src/main/java/com/project/Transflow/notification/service/TranslationNotificationMailService.java
+++ b/src/main/java/com/project/Transflow/notification/service/TranslationNotificationMailService.java
@@ -1,0 +1,54 @@
+package com.project.Transflow.notification.service;
+
+import com.project.Transflow.user.entity.User;
+import com.project.Transflow.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TranslationNotificationMailService {
+
+    private final JavaMailSender mailSender;
+    private final UserRepository userRepository;
+
+    @Value("${app.reviews.url:https://lb.walab.info/reviews}")
+    private String reviewsUrl;
+
+    public void sendTranslationCompletedToAdmins(Long documentId, String documentTitle) {
+        List<String> recipients = userRepository.findByRoleLevelLessThanEqual(2).stream()
+                .map(User::getEmail)
+                .filter(email -> email != null && !email.isBlank())
+                .distinct()
+                .collect(Collectors.toList());
+
+        if (recipients.isEmpty()) {
+            log.info("번역 완료 알림 메일 스킵 - 관리자 수신자 없음: documentId={}", documentId);
+            return;
+        }
+
+        String safeTitle = (documentTitle == null || documentTitle.isBlank()) ? "(제목 없음)" : documentTitle;
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(recipients.toArray(new String[0]));
+        message.setSubject("[LangBridge] 번역 완료 알림");
+        message.setText(
+                "번역이 완료되었습니다.\n\n"
+                        + "- 문서 ID: " + documentId + "\n"
+                        + "- 문서명: " + safeTitle + "\n\n"
+                        + "아래 리뷰 페이지에서 확인해 주세요.\n"
+                        + reviewsUrl
+        );
+
+        mailSender.send(message);
+        log.info("번역 완료 알림 메일 발송 완료: documentId={}, recipients={}", documentId, recipients.size());
+    }
+}

--- a/src/main/java/com/project/Transflow/translate/service/KoreanStylePostProcessor.java
+++ b/src/main/java/com/project/Transflow/translate/service/KoreanStylePostProcessor.java
@@ -1,0 +1,51 @@
+package com.project.Transflow.translate.service;
+
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+@Component
+public class KoreanStylePostProcessor {
+
+    private static final Pattern KOREAN_CHAR_PATTERN = Pattern.compile(".*[가-힣].*");
+
+    /**
+     * 한국어 번역 결과를 평어체(이다체) 중심으로 보정합니다.
+     * 과도한 변환을 막기 위해 문장 종결 표현 위주로 최소 치환만 수행합니다.
+     */
+    public String toPlainStyle(String text) {
+        if (text == null || text.isBlank()) {
+            return text;
+        }
+        if (!KOREAN_CHAR_PATTERN.matcher(text).matches()) {
+            return text;
+        }
+
+        String result = text;
+
+        // 치환 순서가 중요하므로 LinkedHashMap 사용
+        Map<String, String> replacements = new LinkedHashMap<>();
+        replacements.put("였습니다.", "였다.");
+        replacements.put("였습니다", "였다");
+        replacements.put("입니다.", "이다.");
+        replacements.put("입니다", "이다");
+        replacements.put("합니다.", "한다.");
+        replacements.put("합니다", "한다");
+        replacements.put("했습니다.", "했다.");
+        replacements.put("했습니다", "했다");
+        replacements.put("됩니다.", "된다.");
+        replacements.put("됩니다", "된다");
+        replacements.put("있습니다.", "있다.");
+        replacements.put("있습니다", "있다");
+        replacements.put("없습니다.", "없다.");
+        replacements.put("없습니다", "없다");
+
+        for (Map.Entry<String, String> entry : replacements.entrySet()) {
+            result = result.replace(entry.getKey(), entry.getValue());
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/project/Transflow/translate/service/TranslationService.java
+++ b/src/main/java/com/project/Transflow/translate/service/TranslationService.java
@@ -20,11 +20,14 @@ public class TranslationService {
 
     private final WebClient webClient;
     private final ApiKeyService apiKeyService;
+    private final KoreanStylePostProcessor koreanStylePostProcessor;
 
     public TranslationService(
             @Value("${deepl.api.url}") String apiUrl,
-            ApiKeyService apiKeyService) {
+            ApiKeyService apiKeyService,
+            KoreanStylePostProcessor koreanStylePostProcessor) {
         this.apiKeyService = apiKeyService;
+        this.koreanStylePostProcessor = koreanStylePostProcessor;
         this.webClient = WebClient.builder()
                 .baseUrl(apiUrl)
                 .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(10 * 1024 * 1024)) // 10MB
@@ -124,7 +127,7 @@ public class TranslationService {
                 if (response != null && response.getTranslations() != null && !response.getTranslations().isEmpty()) {
                     List<String> translatedTexts = new ArrayList<>();
                     for (com.project.Transflow.translate.dto.DeepLResponse.Translation translation : response.getTranslations()) {
-                        translatedTexts.add(translation.getText());
+                        translatedTexts.add(applyKoreanPlainStyle(translation.getText(), targetLang));
                     }
                     return translatedTexts;
                 }
@@ -232,7 +235,7 @@ public class TranslationService {
 
             if (response != null && response.getTranslations() != null && !response.getTranslations().isEmpty()) {
                 String translatedText = response.getTranslations().get(0).getText();
-                return translatedText;
+                return applyKoreanPlainStyle(translatedText, targetLang);
             }
 
             throw new RuntimeException("번역 결과가 비어있습니다.");
@@ -294,5 +297,15 @@ public class TranslationService {
         }
         
         throw new RuntimeException("번역 실패: 최대 재시도 횟수 초과");
+    }
+
+    private String applyKoreanPlainStyle(String translatedText, String targetLang) {
+        if (translatedText == null) {
+            return null;
+        }
+        if (targetLang == null || !"KO".equalsIgnoreCase(targetLang)) {
+            return translatedText;
+        }
+        return koreanStylePostProcessor.toPlainStyle(translatedText);
     }
 }

--- a/src/main/java/com/project/Transflow/user/repository/UserRepository.java
+++ b/src/main/java/com/project/Transflow/user/repository/UserRepository.java
@@ -4,12 +4,14 @@ import com.project.Transflow.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findByGoogleId(String googleId);
+    List<User> findByRoleLevelLessThanEqual(Integer roleLevel);
     boolean existsByEmail(String email);
     long count();
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,6 +49,18 @@ spring:
             user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
             user-name-attribute: sub
 
+  mail:
+    host: ${MAIL_HOST:smtp.gmail.com}
+    port: ${MAIL_PORT:587}
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 # JWT 설정
 jwt:
   secret: ${JWT_SECRET:transflow-secret-key-for-jwt-token-generation-minimum-256-bits}


### PR DESCRIPTION
issue: #62 
## [BE] 번역 완료 관리자 메일 알림 + 한국어 평어체 후처리 + my-copy 예외 대응
### 배경
- 번역 완료 시 관리자에게 리뷰 요청 메일 자동 알림 필요
- 한국어 번역 문체를 존댓말(`~합니다`)이 아닌 평어체(`~한다`)로 맞출 필요
- `findMyCopyBySourceId`에서 `NonUniqueResultException` 발생 (중복 복사본 데이터 존재 시 단건 조회 실패)
### 변경 사항
- 번역 완료 메일 알림 기능 추가
  - 번역 완료 시 `roleLevel <= 2` 관리자 대상 메일 발송
  - 메일 본문에 리뷰 URL(`https://lb.walab.info/reviews`) 포함
  - 메일 실패 시 번역 완료 흐름은 유지하고 에러 로그만 기록
- 메일 인프라 설정 추가
  - `spring-boot-starter-mail` 의존성 추가
  - `application.yml`에 `MAIL_HOST/MAIL_PORT/MAIL_USERNAME/MAIL_PASSWORD` 환경변수 기반 SMTP 설정
- 한국어 평어체 후처리 추가
  - `KoreanStylePostProcessor` 도입
  - 타겟 언어가 `KO`인 경우 번역 결과 후처리 적용
- 운영 이슈 확인
  - SMTP `535 BadCredentials`는 포트 문제가 아니라 계정/앱비밀번호 자격증명 문제로 확인됨
- 후속 필요 이슈(미해결)
  - `findMyCopyBySourceId` 단건 가정 로직 재설계 필요
  - 최신 1건 조회 방식 또는 DB 유니크 제약/중복 정리 전략 필요
### 기대 효과
- 번역 완료 후 검토 파이프라인(관리자 알림) 자동화
- 한국어 결과 문체 일관성 개선
- `my-copy` 조회 안정성 개선 필요성 명확화
### 검증 항목
- [ ] 번역 완료 API 호출 시 관리자 메일 수신 확인
- [ ] `MAIL_*` 변경 후 서버 재기동 시 정상 반영 확인
- [ ] KO 번역 결과가 평어체로 출력되는지 확인
- [ ] 중복 복사본 데이터 환경에서 `my-copy` 조회 예외 재현 및 개선안 검증
